### PR TITLE
[MM-11896] Do not use minimize shortcut on win32 (#971)

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -191,6 +191,9 @@ function createTemplate(mainWindow, config, isDev) {
     label: '&Window',
     submenu: [{
       role: 'minimize',
+
+      // empty string removes shortcut on Windows; null will default by OS
+      accelerator: process.platform === 'win32' ? '' : null,
     }, {
       role: 'close',
     }, separatorItem, ...teams.slice(0, 9).map((team, i) => {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [ ] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [ ] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
<!--
Write a short (one line) summary that describes the changes in this pull request for inclusion in the changelog
-->

**Issue link**
<!--
Please include a link to the GitHub issue this pull request addresses, if applicable.
-->

**Test Cases**

**Additional Notes**
